### PR TITLE
fix(blueprint) compute destAbsolutepath after renaming any files

### DIFF
--- a/src/blueprint.ts
+++ b/src/blueprint.ts
@@ -190,12 +190,13 @@ export default class Blueprint extends Command {
         sourceURL: relativepath
       });
       let destRelativepath = filenameTemplate(data);
-      let destAbsolutepath = path.join(dest, destRelativepath);
       let basename = path.basename(destRelativepath);
       
       if (renamedFiles[basename]) {
           destRelativepath = path.join(path.dirname(destRelativepath), renamedFiles[basename]);
       }
+
+      let destAbsolutepath = path.join(dest, destRelativepath);
 
       if (fs.existsSync(destAbsolutepath)) {
         ui.info(`${ chalk.green('already exists') } ${ destRelativepath }`);


### PR DESCRIPTION
This fixes the issue shown in denali-js/denali#252 where the .gitignore files aren't being renamed correctly.

/cc @davewasmer 