### PR TITLE
Add yarn.lock to list of files to copy into `dist` folder

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -93,7 +93,8 @@ export default class Builder {
     'README.md',
     'CHANGELOG.md',
     'LICENSE',
-    'denali-build.js'
+    'denali-build.js',
+    'yarn.lock'
   ];
 
   /**


### PR DESCRIPTION
This may not necessarily affect addons, but it would probably be a good idea to do this for apps built in production.

Using this, you can add an app's `dist` folder to a dockerfile or whatever service will be running the production app, and then run `yarn install --prod` to avoid needing to install dev dependencies.