### PR TITLE
fix(project): queue spinner promises on watch

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -237,16 +237,21 @@ export default class Project {
       addonProject.watch({ onBuild: options.onBuild, outputDir: addonDist });
     });
 
+    let spinnerStart: Promise<void>;
+
     // Handle watcher events
     watcher.on('buildstart', async () => {
       debug('changes detected, rebuilding');
-      await spinner.start(`Building ${ this.pkg.name }`);
       timer = startTimer();
+      spinnerStart = spinner.start(`Building ${ this.pkg.name }`);
+      await spinnerStart;
     });
     watcher.on('change', async (results: { directory: string, graph: any }) => {
       debug('rebuild finished, wrapping up');
       this.finishBuild(results, options.outputDir);
+      await spinnerStart;
       await spinner.succeed(`${ this.pkg.name } build complete (${ timer.stop() }s)`);
+      spinnerStart = null;
       options.onBuild(this);
     });
     watcher.on('error', async (error: any) => {


### PR DESCRIPTION
fixes #19
- on fast rebuilds, the change event would be fired quickly enough that
it would cause the spinner to succeed before it could be started
completely. This ensures the succeed call happens after the start call.
It also fixes the timer