### PR TITLE
fix(blueprint): loosen restriction on denali version in blueprints

### DIFF
--- a/blueprints/addon/files/__name__/package.json
+++ b/blueprints/addon/files/__name__/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "eslint-config-denali": "^1.1.0",
-    "denali": "0.0.26",
+    "denali": "0.0.x",
     "denali-cli": "0.0.x",
     "in-publish": "^2.0.0",
     "lodash": "^4.16.4"

--- a/blueprints/app/files/__name__/package.json
+++ b/blueprints/app/files/__name__/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "eslint-config-denali": "^1.1.2",
-    "denali": "0.0.26",
+    "denali": "0.0.x",
     "denali-cli": "0.0.x",
     "lodash": "^4.0.0"
   },


### PR DESCRIPTION
no issue
- the version in package.json was pinned at `0.0.26`. until denali goes into 0.1.0-beta, it should be less restrictive so it gets the latest alpha version for newly generated apps/addons