### PR TITLE
fix(builders): use 'app' as the name for unitTestBundle

### DIFF
--- a/lib/builders/base.ts
+++ b/lib/builders/base.ts
@@ -221,7 +221,7 @@ export default class BaseBuilder {
   }
 
   unitTestBundleName() {
-    return this.pkg.name;
+    return 'app';
   }
 
   /**


### PR DESCRIPTION
Resolves #53