### PR TITLE
fix(blueprints): assign blueprint key with addon name prefix

### DIFF
--- a/lib/blueprint.ts
+++ b/lib/blueprint.ts
@@ -129,8 +129,11 @@ export default class Blueprint extends Command {
         } catch (e) {
           throw new NestedError(`Unable to load blueprint from ${ dir } -> ${ dirname }`, e);
         }
+        // Assign name of blueprint to be namespaced by addon name if not a core blueprint
+        let isCoreBlueprint = addonName === '@denali-js/core' || addonName === '@denali-js/cli';
+        let blueprintKey = isCoreBlueprint ? dirname : `${ addonName }:${ dirname }`;
         BlueprintClass.addon = addonName;
-        BlueprintsSoFar[dirname] = BlueprintClass;
+        BlueprintsSoFar[blueprintKey] = BlueprintClass;
         return BlueprintsSoFar;
       }, {});
     // Capture the source directory of the blueprint


### PR DESCRIPTION
This resolves `default` blueprint type or any other blueprint with the same name cross addon from clobbering each other.